### PR TITLE
Only set the windowLayoutInDisplayCutoutMode to always on Android 11 …

### DIFF
--- a/app/src/main/res/values-v30/themes.xml
+++ b/app/src/main/res/values-v30/themes.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.ScreenLit.Fullscreen" parent="Theme.ScreenLit">
-        <item name="android:actionBarStyle">@style/Widget.Theme.ScreenLit.ActionBar.Fullscreen
-        </item>
+    <style name="Theme.ScreenLit.Fullscreen">
+        <item name="android:actionBarStyle">@style/Widget.Theme.ScreenLit.ActionBar.Fullscreen</item>
         <item name="android:windowActionBarOverlay">true</item>
         <item name="android:windowBackground">@null</item>
         <item name="android:windowFullscreen">true</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,7 +7,7 @@
         <item name="android:statusBarColor">@color/grey_100</item>
     </style>
 
-    <style name="Theme.ScreenLit.Fullscreen" parent="Theme.ScreenLit">
+    <style name="Theme.ScreenLit.Fullscreen">
         <item name="android:actionBarStyle">@style/Widget.Theme.ScreenLit.ActionBar.Fullscreen</item>
         <item name="android:windowActionBarOverlay">true</item>
         <item name="android:windowBackground">@null</item>


### PR DESCRIPTION
…(API 30) and above for the Activity theme

- On older Android versions this option does not exists which lead to a crash